### PR TITLE
Bump v0.1.13 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "apparmor-psp"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apparmor-psp"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,28 +4,28 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.12
+version: 0.1.13
 name: psp-apparmor
 displayName: Apparmor PSP
-createdAt: 2023-03-27T09:07:43.051650718Z
+createdAt: 2023-07-07T18:35:47.38052711Z
 description: Replacement for the Kubernetes Pod Security Policy that controls the usage of AppArmor profiles
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/apparmor-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/apparmor-psp:v0.1.12
+  image: ghcr.io/kubewarden/policies/apparmor-psp:v0.1.13
 keywords:
 - psp
 - apparmor
 links:
 - name: policy
-  url: https://github.com/kubewarden/apparmor-psp-policy/releases/download/v0.1.12/policy.wasm
+  url: https://github.com/kubewarden/apparmor-psp-policy/releases/download/v0.1.13/policy.wasm
 - name: source
   url: https://github.com/kubewarden/apparmor-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/apparmor-psp:v0.1.12
+  kwctl pull ghcr.io/kubewarden/policies/apparmor-psp:v0.1.13
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Updates the Cargo and artifacthub files bumping the policy version to v0.1.13.

Related to https://github.com/kubewarden/kubewarden-controller/issues/479